### PR TITLE
コマンドライン認証に変更

### DIFF
--- a/bygoogledrive_dw.py
+++ b/bygoogledrive_dw.py
@@ -26,7 +26,7 @@ if credentials_content:
 gauth.LoadCredentialsFile("credentials.json")
 
 if gauth.credentials is None or gauth.access_token_expired:
-    gauth.LocalWebserverAuth()  # 新しい認証情報を取得
+    gauth.CommandLineAuth()  # コマンドライン認証フローを使用
     gauth.SaveCredentialsFile("credentials.json")  # 認証情報を保存
 
 drive = GoogleDrive(gauth)

--- a/bygoogledrive_up.py
+++ b/bygoogledrive_up.py
@@ -26,7 +26,7 @@ if credentials_content:
 gauth.LoadCredentialsFile("credentials.json")
 
 if gauth.credentials is None or gauth.access_token_expired:
-    gauth.LocalWebserverAuth()  # 新しい認証情報を取得
+    gauth.CommandLineAuth()  # コマンドライン認証フローを使用
     gauth.SaveCredentialsFile("credentials.json")  # 認証情報を保存
 
 drive = GoogleDrive(gauth)


### PR DESCRIPTION
クラウド環境ではローカルWebサーバーを使用した認証がうまく機能しないようなので、ローカルWebサーバー認証をコマンドライン認証フローに変更